### PR TITLE
MapSequenceTraverse: don't add redundant parentheses when original source uses braces

### DIFF
--- a/input/src/main/scala/fix/MapSequenceTraverseTest.scala
+++ b/input/src/main/scala/fix/MapSequenceTraverseTest.scala
@@ -6,5 +6,8 @@ package fix
 import cats.syntax.all.*
 
 object MapSequenceTraverseTest {
-  def x: Option[List[Int]] = List(1, 2, 3).map(a => if (a % 2 == 0) Some(a) else None).sequence
+  def withParens: Option[List[Int]] = List(1, 2, 3).map(a => if (a % 2 == 0) Some(a) else None).sequence
+  def withBraces: Option[List[Int]] = List(1, 2, 3).map{a => if (a % 2 == 0) Some(a) else None}.sequence
+  def withParensThenBraces: Option[List[Int]] = List(1, 2, 3).map({a => if (a % 2 == 0) Some(a) else None}).sequence
+  def withBracesThenParens: Option[List[Int]] = List(1, 2, 3).map{(a => if (a % 2 == 0) Some(a) else None)}.sequence
 }

--- a/output/src/main/scala/fix/MapSequenceTraverseTest.scala
+++ b/output/src/main/scala/fix/MapSequenceTraverseTest.scala
@@ -3,5 +3,8 @@ package fix
 import cats.syntax.all.*
 
 object MapSequenceTraverseTest {
-  def x: Option[List[Int]] = List(1, 2, 3).traverse(a => if (a % 2 == 0) Some(a) else None)
+  def withParens: Option[List[Int]] = List(1, 2, 3).traverse(a => if (a % 2 == 0) Some(a) else None)
+  def withBraces: Option[List[Int]] = List(1, 2, 3).traverse{a => if (a % 2 == 0) Some(a) else None}
+  def withParensThenBraces: Option[List[Int]] = List(1, 2, 3).traverse{a => if (a % 2 == 0) Some(a) else None}
+  def withBracesThenParens: Option[List[Int]] = List(1, 2, 3).traverse{(a => if (a % 2 == 0) Some(a) else None)}
 }

--- a/rules/src/main/scala/fix/MapSequenceTraverse.scala
+++ b/rules/src/main/scala/fix/MapSequenceTraverse.scala
@@ -3,7 +3,9 @@ package fix
 import scalafix.Patch
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
+
 import scala.meta.Term
+import scala.meta.tokens.Token.{LeftBrace, RightBrace}
 
 class MapSequenceTraverse extends SyntacticRule("MapSequenceTraverse") {
   override def fix(implicit doc: SyntacticDocument): Patch = {
@@ -18,7 +20,10 @@ class MapSequenceTraverse extends SyntacticRule("MapSequenceTraverse") {
             ),
             Term.Name("sequence")
           ) =>
-        Patch.replaceTree(t, s"${qual}.traverse(${arg})")
+        (arg.tokens.headOption, arg.tokens.lastOption) match {
+          case (Some(LeftBrace()), Some(RightBrace())) => Patch.replaceTree(t, s"${qual}.traverse${arg}")
+          case _ => Patch.replaceTree(t, s"${qual}.traverse(${arg})")
+        }
     }
   }.asPatch
 }

--- a/rules/src/main/scala/fix/MapSequenceTraverse.scala
+++ b/rules/src/main/scala/fix/MapSequenceTraverse.scala
@@ -3,7 +3,6 @@ package fix
 import scalafix.Patch
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
-
 import scala.meta.Term
 import scala.meta.tokens.Token.{LeftBrace, RightBrace}
 


### PR DESCRIPTION
@xuwei-k I recently starting using some of these scalafix rules and they are great, thank you for developing them

I noticed for the `MapSequenceTraverse` rule that if braces are used instead of parentheses, the rewrite wraps the braces in redundant parentheses
```diff
- collection.map {  x =>
-  if (a % 2 == 0) Some(a) else None
- }.sequence
+collection.traverse({ a =>
+  if (a % 2 == 0) Some(a) else None
+})
```

this patch detects that case and avoids adding the redundant parentheses, its possible there is a more elegant solution out there - this is my first scalafix contribution 
