### PR TITLE
add "message" config

### DIFF
--- a/rules/src/main/scala/fix/AutoEtaExpansion.scala
+++ b/rules/src/main/scala/fix/AutoEtaExpansion.scala
@@ -1,21 +1,47 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Term
 import scala.meta.XtensionCollectionLikeUI
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
 import scalafix.patch.Patch
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionSeqPatch
 
-class AutoEtaExpansion extends SyntacticRule("AutoEtaExpansion") {
+final case class AutoEtaExpansionConfig(
+  message: String
+)
+
+object AutoEtaExpansionConfig {
+  val default: AutoEtaExpansionConfig = AutoEtaExpansionConfig(
+    message = "remove `_` https://docs.scala-lang.org/scala3/reference/changed-features/eta-expansion.html"
+  )
+
+  implicit val surface: Surface[AutoEtaExpansionConfig] =
+    metaconfig.generic.deriveSurface[AutoEtaExpansionConfig]
+
+  implicit val decoder: ConfDecoder[AutoEtaExpansionConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class AutoEtaExpansion(config: AutoEtaExpansionConfig) extends SyntacticRule("AutoEtaExpansion") {
+
+  def this() = this(AutoEtaExpansionConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("AutoEtaExpansion")(this.config).map(newConfig => new AutoEtaExpansion(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect { case t: Term.Eta =>
       Patch.lint(
         Diagnostic(
           id = "",
-          message = "remove `_` https://docs.scala-lang.org/scala3/reference/changed-features/eta-expansion.html",
+          message = config.message,
           position = t.pos,
           severity = LintSeverity.Warning
         )

--- a/rules/src/main/scala/fix/CaseClassImplicitVal.scala
+++ b/rules/src/main/scala/fix/CaseClassImplicitVal.scala
@@ -1,5 +1,8 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Defn
 import scala.meta.Mod
 import scala.meta.XtensionClassifiable
@@ -7,11 +10,34 @@ import scala.meta.transversers._
 import scalafix.Patch
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionSeqPatch
 
-class CaseClassImplicitVal extends SyntacticRule("CaseClassImplicitVal") {
+final case class CaseClassImplicitValConfig(
+  message: String
+)
+
+object CaseClassImplicitValConfig {
+  val default: CaseClassImplicitValConfig = CaseClassImplicitValConfig(
+    message = "`case class must have at least one leading non-implicit parameter list` error in Scala 3"
+  )
+
+  implicit val surface: Surface[CaseClassImplicitValConfig] =
+    metaconfig.generic.deriveSurface[CaseClassImplicitValConfig]
+
+  implicit val decoder: ConfDecoder[CaseClassImplicitValConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class CaseClassImplicitVal(config: CaseClassImplicitValConfig) extends SyntacticRule("CaseClassImplicitVal") {
+
+  def this() = this(CaseClassImplicitValConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("CaseClassImplicitVal")(this.config).map(newConfig => new CaseClassImplicitVal(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect {
       case t: Defn.Class
@@ -21,7 +47,7 @@ class CaseClassImplicitVal extends SyntacticRule("CaseClassImplicitVal") {
         Patch.lint(
           Diagnostic(
             id = "",
-            message = "`case class must have at least one leading non-implicit parameter list` error in Scala 3",
+            message = config.message,
             position = t.pos,
             severity = LintSeverity.Warning
           )

--- a/rules/src/main/scala/fix/CatsImplicitsImport.scala
+++ b/rules/src/main/scala/fix/CatsImplicitsImport.scala
@@ -1,5 +1,8 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Import
 import scala.meta.Importer
 import scala.meta.Term
@@ -7,11 +10,34 @@ import scala.meta.XtensionCollectionLikeUI
 import scalafix.Patch
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionSeqPatch
 
-class CatsImplicitsImport extends SyntacticRule("CatsImplicitsImport") {
+final case class CatsImplicitsImportConfig(
+  message: String
+)
+
+object CatsImplicitsImportConfig {
+  val default: CatsImplicitsImportConfig = CatsImplicitsImportConfig(
+    message = "use `cats.syntax` instead of `cats.implicits` https://github.com/typelevel/cats/issues/4138"
+  )
+
+  implicit val surface: Surface[CatsImplicitsImportConfig] =
+    metaconfig.generic.deriveSurface[CatsImplicitsImportConfig]
+
+  implicit val decoder: ConfDecoder[CatsImplicitsImportConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class CatsImplicitsImport(config: CatsImplicitsImportConfig) extends SyntacticRule("CatsImplicitsImport") {
+
+  def this() = this(CatsImplicitsImportConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("CatsImplicitsImport")(this.config).map(newConfig => new CatsImplicitsImport(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect {
       case t @ Import(
@@ -20,7 +46,7 @@ class CatsImplicitsImport extends SyntacticRule("CatsImplicitsImport") {
         Patch.lint(
           Diagnostic(
             id = "",
-            message = "use `cats.syntax` instead of `cats.implicits` https://github.com/typelevel/cats/issues/4138",
+            message = config.message,
             position = t.pos,
             severity = LintSeverity.Warning
           )

--- a/rules/src/main/scala/fix/CatsInstancesImport.scala
+++ b/rules/src/main/scala/fix/CatsInstancesImport.scala
@@ -1,16 +1,42 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Importer
 import scala.meta.Term
 import scala.meta.XtensionCollectionLikeUI
 import scalafix.Patch
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionSeqPatch
 
-class CatsInstancesImport extends SyntacticRule("CatsInstancesImport") {
+final case class CatsInstancesImportConfig(
+  message: String
+)
+
+object CatsInstancesImportConfig {
+  val default: CatsInstancesImportConfig = CatsInstancesImportConfig(
+    message = "unnecessary import https://github.com/typelevel/cats/pull/3043"
+  )
+
+  implicit val surface: Surface[CatsInstancesImportConfig] =
+    metaconfig.generic.deriveSurface[CatsInstancesImportConfig]
+
+  implicit val decoder: ConfDecoder[CatsInstancesImportConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class CatsInstancesImport(config: CatsInstancesImportConfig) extends SyntacticRule("CatsInstancesImport") {
+
+  def this() = this(CatsInstancesImportConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("CatsInstancesImport")(this.config).map(newConfig => new CatsInstancesImport(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect {
       case t @ Importer(
@@ -23,7 +49,7 @@ class CatsInstancesImport extends SyntacticRule("CatsInstancesImport") {
         Patch.lint(
           Diagnostic(
             id = "",
-            message = "unnecessary import https://github.com/typelevel/cats/pull/3043",
+            message = config.message,
             position = t.pos,
             severity = LintSeverity.Warning
           )

--- a/rules/src/main/scala/fix/FinalObjectWarn.scala
+++ b/rules/src/main/scala/fix/FinalObjectWarn.scala
@@ -1,5 +1,8 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Defn
 import scala.meta.Mod
 import scala.meta.XtensionClassifiable
@@ -7,12 +10,35 @@ import scala.meta.XtensionCollectionLikeUI
 import scalafix.Patch
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionOptionPatch
 import scalafix.v1.XtensionSeqPatch
 
-class FinalObjectWarn extends SyntacticRule("FinalObjectWarn") {
+final case class FinalObjectWarnConfig(
+  message: String
+)
+
+object FinalObjectWarnConfig {
+  val default: FinalObjectWarnConfig = FinalObjectWarnConfig(
+    message = "Modifier final is redundant"
+  )
+
+  implicit val surface: Surface[FinalObjectWarnConfig] =
+    metaconfig.generic.deriveSurface[FinalObjectWarnConfig]
+
+  implicit val decoder: ConfDecoder[FinalObjectWarnConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class FinalObjectWarn(config: FinalObjectWarnConfig) extends SyntacticRule("FinalObjectWarn") {
+
+  def this() = this(FinalObjectWarnConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("FinalObjectWarn")(this.config).map(newConfig => new FinalObjectWarn(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect { case t: Defn.Object =>
       t.mods
@@ -21,7 +47,7 @@ class FinalObjectWarn extends SyntacticRule("FinalObjectWarn") {
           Patch.lint(
             Diagnostic(
               id = "",
-              message = "Modifier final is redundant",
+              message = config.message,
               position = finalMod.pos,
               severity = LintSeverity.Warning
             )

--- a/rules/src/main/scala/fix/Implicit.scala
+++ b/rules/src/main/scala/fix/Implicit.scala
@@ -1,20 +1,46 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.tokens.Token
 import scalafix.Patch
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionSeqPatch
 
-class Implicit extends SyntacticRule("Implicit") {
+final case class ImplicitConfig(
+  message: String
+)
+
+object ImplicitConfig {
+  val default: ImplicitConfig = ImplicitConfig(
+    message = "don't use `implicit`. use `given`, `using` or `extension`"
+  )
+
+  implicit val surface: Surface[ImplicitConfig] =
+    metaconfig.generic.deriveSurface[ImplicitConfig]
+
+  implicit val decoder: ConfDecoder[ImplicitConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class Implicit(config: ImplicitConfig) extends SyntacticRule("Implicit") {
+
+  def this() = this(ImplicitConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("Implicit")(this.config).map(newConfig => new Implicit(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tokens.collect { case t: Token.KwImplicit =>
       Patch.lint(
         Diagnostic(
           id = "",
-          message = "don't use `implicit`. use `given`, `using` or `extension`",
+          message = config.message,
           position = t.pos,
           severity = LintSeverity.Warning
         )

--- a/rules/src/main/scala/fix/InterpolationToStringWarn.scala
+++ b/rules/src/main/scala/fix/InterpolationToStringWarn.scala
@@ -1,16 +1,45 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Term
 import scala.meta.Tree
 import scala.meta.XtensionCollectionLikeUI
 import scalafix.Diagnostic
 import scalafix.Patch
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionSeqPatch
 
-class InterpolationToStringWarn extends SyntacticRule("InterpolationToStringWarn") {
+final case class InterpolationToStringWarnConfig(
+  message: String
+)
+
+object InterpolationToStringWarnConfig {
+  val default: InterpolationToStringWarnConfig = InterpolationToStringWarnConfig(
+    message = "maybe unnecessary `toString` in the `s` interpolation"
+  )
+
+  implicit val surface: Surface[InterpolationToStringWarnConfig] =
+    metaconfig.generic.deriveSurface[InterpolationToStringWarnConfig]
+
+  implicit val decoder: ConfDecoder[InterpolationToStringWarnConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class InterpolationToStringWarn(config: InterpolationToStringWarnConfig)
+    extends SyntacticRule("InterpolationToStringWarn") {
+
+  def this() = this(InterpolationToStringWarnConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf
+      .getOrElse("InterpolationToStringWarn")(this.config)
+      .map(newConfig => new InterpolationToStringWarn(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect {
       case Term.Interpolate(
@@ -27,7 +56,7 @@ class InterpolationToStringWarn extends SyntacticRule("InterpolationToStringWarn
           Patch.lint(
             Diagnostic(
               id = "",
-              message = "maybe unnecessary `toString` in the `s` interpolation",
+              message = config.message,
               position = t.pos,
               severity = LintSeverity.Warning
             )

--- a/rules/src/main/scala/fix/IntersectionType.scala
+++ b/rules/src/main/scala/fix/IntersectionType.scala
@@ -1,21 +1,47 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Type
 import scala.meta.transversers._
 import scalafix.Patch
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionSeqPatch
 
-class IntersectionType extends SyntacticRule("IntersectionType") {
+final case class IntersectionTypeConfig(
+  message: String
+)
+
+object IntersectionTypeConfig {
+  val default: IntersectionTypeConfig = IntersectionTypeConfig(
+    message = "use `&` instead of `with`"
+  )
+
+  implicit val surface: Surface[IntersectionTypeConfig] =
+    metaconfig.generic.deriveSurface[IntersectionTypeConfig]
+
+  implicit val decoder: ConfDecoder[IntersectionTypeConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class IntersectionType(config: IntersectionTypeConfig) extends SyntacticRule("IntersectionType") {
+
+  def this() = this(IntersectionTypeConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("IntersectionType")(this.config).map(newConfig => new IntersectionType(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect { case t: Type.With =>
       Patch.lint(
         Diagnostic(
           id = "",
-          message = "use `&` instead of `with`",
+          message = config.message,
           position = t.pos,
           severity = LintSeverity.Warning
         )

--- a/rules/src/main/scala/fix/JavaURLConstructorsWarn.scala
+++ b/rules/src/main/scala/fix/JavaURLConstructorsWarn.scala
@@ -1,23 +1,51 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Term
 import scala.meta.XtensionCollectionLikeUI
 import scalafix.Patch
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SemanticDocument
 import scalafix.v1.SemanticRule
 import scalafix.v1.XtensionSeqPatch
 import scalafix.v1.XtensionTreeScalafix
 
-class JavaURLConstructorsWarn extends SemanticRule("JavaURLConstructorsWarn") {
+final case class JavaURLConstructorsWarnConfig(
+  message: String
+)
+
+object JavaURLConstructorsWarnConfig {
+  val default: JavaURLConstructorsWarnConfig = JavaURLConstructorsWarnConfig(
+    message = "https://bugs.openjdk.org/browse/JDK-8295949"
+  )
+
+  implicit val surface: Surface[JavaURLConstructorsWarnConfig] =
+    metaconfig.generic.deriveSurface[JavaURLConstructorsWarnConfig]
+
+  implicit val decoder: ConfDecoder[JavaURLConstructorsWarnConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class JavaURLConstructorsWarn(config: JavaURLConstructorsWarnConfig) extends SemanticRule("JavaURLConstructorsWarn") {
+
+  def this() = this(JavaURLConstructorsWarnConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf
+      .getOrElse("JavaURLConstructorsWarn")(this.config)
+      .map(newConfig => new JavaURLConstructorsWarn(newConfig))
+  }
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
       case x: Term.New if x.init.tpe.symbol.value == "java/net/URL#" =>
         Patch.lint(
           Diagnostic(
             id = "",
-            message = "https://bugs.openjdk.org/browse/JDK-8295949",
+            message = config.message,
             position = x.init.tpe.pos,
             explanation = "https://github.com/openjdk/jdk/commit/4338f527aa81350e3636dcfbcd2eb17ddaad3914",
             severity = LintSeverity.Warning

--- a/rules/src/main/scala/fix/LeakingImplicitClassValAll.scala
+++ b/rules/src/main/scala/fix/LeakingImplicitClassValAll.scala
@@ -1,5 +1,8 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Defn
 import scala.meta.Mod
 import scala.meta.Name
@@ -11,10 +14,36 @@ import scalafix.XtensionOptionPatch
 import scalafix.XtensionSeqPatch
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 
-class LeakingImplicitClassValAll extends SyntacticRule("LeakingImplicitClassValAll") {
+final case class LeakingImplicitClassValAllConfig(
+  message: String
+)
+
+object LeakingImplicitClassValAllConfig {
+  val default: LeakingImplicitClassValAllConfig = LeakingImplicitClassValAllConfig(
+    message = "make private implicit class underlying value"
+  )
+
+  implicit val surface: Surface[LeakingImplicitClassValAllConfig] =
+    metaconfig.generic.deriveSurface[LeakingImplicitClassValAllConfig]
+
+  implicit val decoder: ConfDecoder[LeakingImplicitClassValAllConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class LeakingImplicitClassValAll(config: LeakingImplicitClassValAllConfig)
+    extends SyntacticRule("LeakingImplicitClassValAll") {
+
+  def this() = this(LeakingImplicitClassValAllConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf
+      .getOrElse("LeakingImplicitClassValAll")(this.config)
+      .map(newConfig => new LeakingImplicitClassValAll(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect {
       case t: Defn.Class if t.mods.exists(_.is[Mod.Implicit]) =>
@@ -26,7 +55,7 @@ class LeakingImplicitClassValAll extends SyntacticRule("LeakingImplicitClassValA
               Patch.lint(
                 Diagnostic(
                   id = "",
-                  message = "make private implicit class underlying value",
+                  message = config.message,
                   position = t.name.pos,
                   severity = LintSeverity.Warning
                 )

--- a/rules/src/main/scala/fix/ObjectSelfType.scala
+++ b/rules/src/main/scala/fix/ObjectSelfType.scala
@@ -1,16 +1,42 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Defn
 import scala.meta.XtensionCollectionLikeUI
 import scalafix.Diagnostic
 import scalafix.Patch
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionOptionPatch
 import scalafix.v1.XtensionSeqPatch
 
-class ObjectSelfType extends SyntacticRule("ObjectSelfType") {
+final case class ObjectSelfTypeConfig(
+  message: String
+)
+
+object ObjectSelfTypeConfig {
+  val default: ObjectSelfTypeConfig = ObjectSelfTypeConfig(
+    message = "objects must not have a self type"
+  )
+
+  implicit val surface: Surface[ObjectSelfTypeConfig] =
+    metaconfig.generic.deriveSurface[ObjectSelfTypeConfig]
+
+  implicit val decoder: ConfDecoder[ObjectSelfTypeConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class ObjectSelfType(config: ObjectSelfTypeConfig) extends SyntacticRule("ObjectSelfType") {
+
+  def this() = this(ObjectSelfTypeConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("ObjectSelfType")(this.config).map(newConfig => new ObjectSelfType(newConfig))
+  }
   override def isLinter = true
 
   override def fix(implicit doc: SyntacticDocument): Patch = {
@@ -21,7 +47,7 @@ class ObjectSelfType extends SyntacticRule("ObjectSelfType") {
             Diagnostic(
               id = "",
               position = self.pos,
-              message = "objects must not have a self type",
+              message = config.message,
               severity = LintSeverity.Warning,
             )
           )

--- a/rules/src/main/scala/fix/OptionGetWarn.scala
+++ b/rules/src/main/scala/fix/OptionGetWarn.scala
@@ -1,12 +1,17 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Term
 import scala.meta.XtensionCollectionLikeUI
 import scalafix.Patch
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
 import scalafix.v1.ByNameType
+import scalafix.v1.Configuration
 import scalafix.v1.MethodSignature
+import scalafix.v1.Rule
 import scalafix.v1.SemanticDocument
 import scalafix.v1.SemanticRule
 import scalafix.v1.TypeRef
@@ -15,13 +20,34 @@ import scalafix.v1.XtensionOptionPatch
 import scalafix.v1.XtensionSeqPatch
 import scalafix.v1.XtensionTreeScalafix
 
-class OptionGetWarn extends SemanticRule("OptionGetWarn") {
+final case class OptionGetWarnConfig(
+  message: String
+)
+
+object OptionGetWarnConfig {
+  val default: OptionGetWarnConfig = OptionGetWarnConfig(
+    message = "Don't use Option.get"
+  )
+
+  implicit val surface: Surface[OptionGetWarnConfig] =
+    metaconfig.generic.deriveSurface[OptionGetWarnConfig]
+
+  implicit val decoder: ConfDecoder[OptionGetWarnConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+class OptionGetWarn(config: OptionGetWarnConfig) extends SemanticRule("OptionGetWarn") {
+
+  def this() = this(OptionGetWarnConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("OptionGetWarn")(this.config).map(newConfig => new OptionGetWarn(newConfig))
+  }
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect { case Term.Select(obj, get @ Term.Name("get")) =>
       def p = Patch.lint(
         Diagnostic(
           id = "",
-          message = "Don't use Option.get",
+          message = config.message,
           position = get.pos,
           severity = LintSeverity.Warning
         )

--- a/rules/src/main/scala/fix/ParameterUntuplingCaseWarn.scala
+++ b/rules/src/main/scala/fix/ParameterUntuplingCaseWarn.scala
@@ -1,5 +1,8 @@
 package fix
 
+import metaconfig.ConfDecoder
+import metaconfig.Configured
+import metaconfig.generic.Surface
 import scala.meta.Case
 import scala.meta.Pat
 import scala.meta.Term
@@ -8,17 +11,45 @@ import scala.meta.XtensionCollectionLikeUI
 import scala.meta.tokens.Token
 import scalafix.lint.Diagnostic
 import scalafix.lint.LintSeverity
+import scalafix.v1.Configuration
 import scalafix.v1.Patch
+import scalafix.v1.Rule
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 import scalafix.v1.XtensionOptionPatch
 import scalafix.v1.XtensionSeqPatch
 
+final case class ParameterUntuplingCaseWarnConfig(
+  message: String
+)
+
+object ParameterUntuplingCaseWarnConfig {
+  val default: ParameterUntuplingCaseWarnConfig = ParameterUntuplingCaseWarnConfig(
+    message =
+      "unnecessary `case` if scala 3 https://docs.scala-lang.org/scala3/reference/other-new-features/parameter-untupling.html"
+  )
+
+  implicit val surface: Surface[ParameterUntuplingCaseWarnConfig] =
+    metaconfig.generic.deriveSurface[ParameterUntuplingCaseWarnConfig]
+
+  implicit val decoder: ConfDecoder[ParameterUntuplingCaseWarnConfig] =
+    metaconfig.generic.deriveDecoder(default)
+}
+
 /**
  * [[https://docs.scala-lang.org/scala3/reference/other-new-features/parameter-untupling.html]]
  * [[https://docs.scala-lang.org/scala3/reference/other-new-features/parameter-untupling-spec.html]]
  */
-class ParameterUntuplingCaseWarn extends SyntacticRule("ParameterUntuplingCaseWarn") {
+class ParameterUntuplingCaseWarn(config: ParameterUntuplingCaseWarnConfig)
+    extends SyntacticRule("ParameterUntuplingCaseWarn") {
+
+  def this() = this(ParameterUntuplingCaseWarnConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf
+      .getOrElse("ParameterUntuplingCaseWarn")(this.config)
+      .map(newConfig => new ParameterUntuplingCaseWarn(newConfig))
+  }
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect {
       case Term.PartialFunction(
@@ -42,8 +73,7 @@ class ParameterUntuplingCaseWarn extends SyntacticRule("ParameterUntuplingCaseWa
             Patch.lint(
               Diagnostic(
                 id = "",
-                message =
-                  "unnecessary `case` if scala 3 https://docs.scala-lang.org/scala3/reference/other-new-features/parameter-untupling.html",
+                message = config.message,
                 position = c.pos,
                 severity = LintSeverity.Warning
               )


### PR DESCRIPTION
```scala
import scala.meta.Defn
import scala.meta.Lit
import scala.meta.Term
import scala.meta.Type
import scala.meta.transversers._
import scalafix.Patch
import scalafix.v1.SyntacticDocument
import scalafix.v1.SyntacticRule
import scalafix.v1.XtensionSeqPatch

class AddMessageConfig extends SyntacticRule("AddMessageConfig") {
  override def fix(implicit doc: SyntacticDocument): Patch = {
    if (
      doc.tree.collect {
        case Term.Apply.After_4_6_0(
              Term.Select(
                Term.Name("Patch"),
                Term.Name("lint")
              ),
              _
            ) =>
          ()
      }.nonEmpty && doc.tree.collect { case Term.Name("withConfiguration") =>
        ()
      }.isEmpty
    ) {
      doc.tree.collect {
        case c: Defn.Class if c.ctor.paramClauses.isEmpty && c.templ.inits.exists(_.collect {
              case Type.Name("SyntacticRule" | "SemanticRule") => ()
            }.nonEmpty) =>
          val configClassName = s"${c.name.value}Config"
          PartialFunction
            .condOpt(doc.tree.collect {
              case Term.Assign(
                    Term.Name("message"),
                    m: Lit.String
                  ) =>
                m
            }) { case List(msg) =>
              Seq(
                Patch.replaceTree(msg, "config.message"),
                Patch.addLeft(
                  c,
                  s"""
                     |import metaconfig.ConfDecoder
                     |import metaconfig.Configured
                     |import metaconfig.generic.Surface
                     |import scalafix.v1.Configuration
                     |import scalafix.v1.Rule
                     |
                     |final case class ${configClassName}(
                     |  message: String
                     |)
                     |
                     |object ${configClassName}{
                     |  val default: ${configClassName} = ${configClassName}(
                     |    message = "${msg.value}"
                     |  )
                     |
                     |  implicit val surface: Surface[${configClassName}] =
                     |    metaconfig.generic.deriveSurface[${configClassName}]
                     |
                     |  implicit val decoder: ConfDecoder[${configClassName}] =
                     |    metaconfig.generic.deriveDecoder(default)
                     |}
                     |""".stripMargin
                ),
                Patch.addRight(c.name, s"(config: ${configClassName})"),
                Patch.addLeft(
                  c.templ.body.stats.head,
                  s"""
                     |
                     |  def this() = this(${configClassName}.default)
                     |
                     |  override def withConfiguration(config: Configuration): Configured[Rule] = {
                     |    config.conf
                     |      .getOrElse("${c.name.value}")(this.config)
                     |      .map(newConfig => new ${c.name}(newConfig))
                     |  }
                     |""".stripMargin
                )
              ).asPatch
            }
            .asPatch
      }.asPatch
    } else {
      Patch.empty
    }
  }
}
```